### PR TITLE
Added a resourcePrefix

### DIFF
--- a/pixalytics-core/build.gradle
+++ b/pixalytics-core/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.jfrog.bintray'
 android {
     compileSdkVersion 21
     buildToolsVersion "21.1.2"
+    resourcePrefix "pixalytics__"
 
     defaultConfig {
         minSdkVersion 10


### PR DESCRIPTION
This would have fixed the issue of the overlapping layout names when we
tried the integration the first time. Very handy, and to keep in mind
for future library projects.